### PR TITLE
improve api demo in deploy previews

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -14,7 +14,7 @@ import 'bootstrap/scss/bootstrap.scss';
 import App from './App';
 
 ReactDOM.render(
-  <Router>
+  <Router basename={import.meta.env.VITE_BASE_URL ?? undefined}>
     <RelayEnvironmentProvider environment={RelayEnvironment}>
       <React.Suspense fallback={'Loading...'}><App /></React.Suspense>
     </RelayEnvironmentProvider>

--- a/src/screens/SignatureOrderScreen.tsx
+++ b/src/screens/SignatureOrderScreen.tsx
@@ -16,6 +16,7 @@ import SignActingAsButton from '../components/SignActingAsButton';
 import ExtendSignatureOrderButton from '../components/ExtendSignatureOrderButton';
 import CleanupSignatureOrderButton from '../components/CleanupSignatureOrderButton';
 import ChangeSignatureOrderButton from '../components/ChangeSignatureOrderButton';
+import { url } from 'inspector';
 
 function base64ToBlob( base64 : string, type = "application/pdf" ) {
   const binStr = atob( base64 );
@@ -422,9 +423,9 @@ export default function SignatureOrdersScreen() {
               </td>
               <td>
                 {signatory.downloadHref ? (
-                  <a href={signatory.downloadHref}>Download link (right click and copy link)</a>
+                  <a href={signatoryHref(signatory.downloadHref)}>Download link (right click and copy link)</a>
                 ) : (
-                  <a href={signatory.href}>Sign link (right click and copy link)</a>
+                  <a href={signatoryHref(signatory.href)}>Sign link (right click and copy link)</a>
                 )}
               </td>
               <td style={{display: 'flex', gap: 5, justifyContent: 'flex-end'}}>
@@ -450,6 +451,16 @@ export default function SignatureOrdersScreen() {
       </div>
     </div>
   )
+}
+
+function signatoryHref(input: string) : string {
+  if (input.includes('/signatures/') && import.meta.env.VITE_SIGNATURE_FRONTEND_URI) {
+    const url = new URL(input);
+    url.host = (new URL(import.meta.env.VITE_SIGNATURE_FRONTEND_URI).host);
+    url.pathname = url.pathname.replace('/signatures/', '');
+    return url.href;
+  }
+  return input;
 }
 
 function iTextVersions(input: string) : string[] {


### PR DESCRIPTION
this commit makes it so the api demo automatically uses the deploy preview frontend url for
signing links, which improves the QA experience
greatly.

it also sets the router base URL, so that refresh after routing does not break.