### PR TITLE
fix: check preview flag instead of frontend uri

### DIFF
--- a/src/screens/SignatureOrderScreen.tsx
+++ b/src/screens/SignatureOrderScreen.tsx
@@ -453,7 +453,9 @@ export default function SignatureOrdersScreen() {
 }
 
 function signatoryHref(input: string) : string {
-  if (input.includes('/signatures/') && import.meta.env.VITE_SIGNATURE_FRONTEND_URI) {
+  // when running in a preview instance, replace the signatory href host with the deploy preview
+  // VITE_SIGNATURE_FRONTEND_URI is set in `vite.config.mts`
+  if (input.includes('/signatures/') && import.meta.env.VITE_DETECT_PREVIEW) {
     const url = new URL(input);
     url.host = (new URL(import.meta.env.VITE_SIGNATURE_FRONTEND_URI).host);
     url.pathname = url.pathname.replace('/signatures/', '');


### PR DESCRIPTION
When running in deploy previews, we would like to point the signatory hrefs to those for easier testing.
However, in case of running outside deploy previews, the signatory hrefs unusable until the host has been updated with the proper value.

This commit checks the `VITE_DETECT_PREVIEW` flag instead before performing any replacements for signatory hrefs.